### PR TITLE
Add options to lint TypeScript and/or any file matching a regexp

### DIFF
--- a/nbproject/project.properties
+++ b/nbproject/project.properties
@@ -1,4 +1,4 @@
-#Wed, 09 Jan 2019 10:47:15 +0100
+#Fri, 15 Mar 2019 16:56:17 -0400
 auxiliary.org-netbeans-spi-editor-hints-projects.perProjectHintSettingsFile=nbproject/cfg_hints.xml
 javac.source=1.7
 javac.compilerargs=-Xlint -Xlint\:-serial

--- a/src/se/jocke/nb/eslint/Constants.java
+++ b/src/se/jocke/nb/eslint/Constants.java
@@ -9,6 +9,9 @@ public class Constants {
     public static final String ESLINT_PATH = "eslint.path";
     public static final String ESLINT_CONF = "eslint.conf";
     public static final String PATH_ENV_VAR = "PATH_ENV_VAR";
+    public static final String LINT_JAVASCRIPT = "LINT_JAVASCRIPT";
+    public static final String LINT_TYPESCRIPT = "LINT_TYPESCRIPT";
+    public static final String LINT_REGEXP = "LINT_REGEXP";
 
     private Constants() {
     }

--- a/src/se/jocke/nb/eslint/annotation/ESLintAnnotationProvider.java
+++ b/src/se/jocke/nb/eslint/annotation/ESLintAnnotationProvider.java
@@ -23,6 +23,7 @@ import org.openide.util.lookup.ServiceProvider;
 import se.jocke.nb.eslint.ESLint;
 import se.jocke.nb.eslint.error.ErrorReporter;
 import se.jocke.nb.eslint.error.LintError;
+import se.jocke.nb.eslint.options.OptionsUtil;
 
 /**
  *
@@ -41,7 +42,7 @@ public class ESLintAnnotationProvider extends FileChangeAdapter implements Annot
     }
 
     public void apply(final FileObject fileObject) {
-        if (fileObject.getMIMEType().contains("javascript")) {
+        if (OptionsUtil.isLintedFile(fileObject)) {
             LOG.log(Level.INFO, "Start index file {0}", fileObject.getMIMEType());
 
             if (MAPPING.containsKey(fileObject)) {

--- a/src/se/jocke/nb/eslint/options/Bundle.properties
+++ b/src/se/jocke/nb/eslint/options/Bundle.properties
@@ -8,3 +8,7 @@ ESLintPanel.confTextField.text=
 ESLintPanel.jLabel4.text=PATH environment variable value. Sample /usr/local/bin:/usr/bin
 ESLintPanel.searchButton.text=Search...
 ESLintPanel.descriptionLabel.text=Full path of ESLint executable (typically eslint or eslint.cmd)
+ESLintPanel.lintTypeScript.text=Lint files with mime type containing 'typescript'
+ESLintPanel.lintJavascript.text=Lint files with mime type containing 'javascript'
+ESLintPanel.lintRegExp.text=
+ESLintPanel.jLabel3.text=Lint files matching regular expression:

--- a/src/se/jocke/nb/eslint/options/ESLintPanel.form
+++ b/src/se/jocke/nb/eslint/options/ESLintPanel.form
@@ -65,8 +65,20 @@
                           </Group>
                       </Group>
                   </Group>
+                  <Group type="102" attributes="0">
+                      <Group type="103" groupAlignment="0" attributes="0">
+                          <Component id="lintTypeScript" min="-2" max="-2" attributes="0"/>
+                          <Component id="lintJavascript" min="-2" max="-2" attributes="0"/>
+                          <Group type="102" alignment="0" attributes="0">
+                              <Component id="jLabel3" min="-2" max="-2" attributes="0"/>
+                              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                              <Component id="lintRegExp" min="-2" pref="191" max="-2" attributes="0"/>
+                          </Group>
+                      </Group>
+                      <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
+                  </Group>
               </Group>
-              <EmptySpace min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -91,7 +103,16 @@
               <Component id="txtPathValue" min="-2" max="-2" attributes="0"/>
               <EmptySpace type="unrelated" max="-2" attributes="0"/>
               <Component id="jLabel4" min="-2" max="-2" attributes="0"/>
-              <EmptySpace pref="12" max="32767" attributes="0"/>
+              <EmptySpace type="separate" max="-2" attributes="0"/>
+              <Component id="lintJavascript" min="-2" max="-2" attributes="0"/>
+              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+              <Component id="lintTypeScript" min="-2" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="3" attributes="0">
+                  <Component id="lintRegExp" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="jLabel3" alignment="3" min="-2" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace pref="49" max="32767" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -110,9 +131,6 @@
           <ResourceString bundle="se/jocke/nb/eslint/options/Bundle.properties" key="ESLintPanel.eslintPathTextField.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
-      <Events>
-        <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="eslintPathTextFieldActionPerformed"/>
-      </Events>
     </Component>
     <Component class="javax.swing.JButton" name="BrowseButton">
       <Properties>
@@ -181,6 +199,35 @@
       <Properties>
         <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
           <ResourceString bundle="se/jocke/nb/eslint/options/Bundle.properties" key="ESLintPanel.descriptionLabel.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JCheckBox" name="lintJavascript">
+      <Properties>
+        <Property name="selected" type="boolean" value="true"/>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="se/jocke/nb/eslint/options/Bundle.properties" key="ESLintPanel.lintJavascript.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JCheckBox" name="lintTypeScript">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="se/jocke/nb/eslint/options/Bundle.properties" key="ESLintPanel.lintTypeScript.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JTextField" name="lintRegExp">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="se/jocke/nb/eslint/options/Bundle.properties" key="ESLintPanel.lintRegExp.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
+        </Property>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JLabel" name="jLabel3">
+      <Properties>
+        <Property name="text" type="java.lang.String" editor="org.netbeans.modules.i18n.form.FormI18nStringEditor">
+          <ResourceString bundle="se/jocke/nb/eslint/options/Bundle.properties" key="ESLintPanel.jLabel3.text" replaceFormat="org.openide.util.NbBundle.getMessage({sourceFileName}.class, &quot;{key}&quot;)"/>
         </Property>
       </Properties>
     </Component>

--- a/src/se/jocke/nb/eslint/options/ESLintPanel.java
+++ b/src/se/jocke/nb/eslint/options/ESLintPanel.java
@@ -40,6 +40,10 @@ final class ESLintPanel extends javax.swing.JPanel {
         txtPathValue = new javax.swing.JTextField();
         searchButton = new javax.swing.JButton();
         descriptionLabel = new javax.swing.JLabel();
+        lintJavascript = new javax.swing.JCheckBox();
+        lintTypeScript = new javax.swing.JCheckBox();
+        lintRegExp = new javax.swing.JTextField();
+        jLabel3 = new javax.swing.JLabel();
 
         fileChooser.setDialogTitle(org.openide.util.NbBundle.getMessage(ESLintPanel.class, "ESLintPanel.fileChooser.dialogTitle")); // NOI18N
         fileChooser.setFileFilter(null);
@@ -82,6 +86,15 @@ final class ESLintPanel extends javax.swing.JPanel {
 
         org.openide.awt.Mnemonics.setLocalizedText(descriptionLabel, org.openide.util.NbBundle.getMessage(ESLintPanel.class, "ESLintPanel.descriptionLabel.text")); // NOI18N
 
+        lintJavascript.setSelected(true);
+        org.openide.awt.Mnemonics.setLocalizedText(lintJavascript, org.openide.util.NbBundle.getMessage(ESLintPanel.class, "ESLintPanel.lintJavascript.text")); // NOI18N
+
+        org.openide.awt.Mnemonics.setLocalizedText(lintTypeScript, org.openide.util.NbBundle.getMessage(ESLintPanel.class, "ESLintPanel.lintTypeScript.text")); // NOI18N
+
+        lintRegExp.setText(org.openide.util.NbBundle.getMessage(ESLintPanel.class, "ESLintPanel.lintRegExp.text")); // NOI18N
+
+        org.openide.awt.Mnemonics.setLocalizedText(jLabel3, org.openide.util.NbBundle.getMessage(ESLintPanel.class, "ESLintPanel.jLabel3.text")); // NOI18N
+
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(this);
         this.setLayout(layout);
         layout.setHorizontalGroup(
@@ -112,7 +125,16 @@ final class ESLintPanel extends javax.swing.JPanel {
                                     .addComponent(BrowseButton, javax.swing.GroupLayout.DEFAULT_SIZE, 95, Short.MAX_VALUE)
                                     .addComponent(browseConfButton, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                                .addComponent(searchButton)))))
+                                .addComponent(searchButton))))
+                    .addGroup(layout.createSequentialGroup()
+                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addComponent(lintTypeScript)
+                            .addComponent(lintJavascript)
+                            .addGroup(layout.createSequentialGroup()
+                                .addComponent(jLabel3)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                                .addComponent(lintRegExp, javax.swing.GroupLayout.PREFERRED_SIZE, 191, javax.swing.GroupLayout.PREFERRED_SIZE)))
+                        .addGap(0, 0, Short.MAX_VALUE)))
                 .addContainerGap())
         );
         layout.setVerticalGroup(
@@ -134,7 +156,15 @@ final class ESLintPanel extends javax.swing.JPanel {
                 .addComponent(txtPathValue, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addComponent(jLabel4)
-                .addContainerGap(12, Short.MAX_VALUE))
+                .addGap(18, 18, 18)
+                .addComponent(lintJavascript)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addComponent(lintTypeScript)
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(lintRegExp, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel3))
+                .addContainerGap(49, Short.MAX_VALUE))
         );
     }// </editor-fold>//GEN-END:initComponents
 
@@ -168,12 +198,18 @@ final class ESLintPanel extends javax.swing.JPanel {
         eslintPathTextField.setText(prefs.get(Constants.ESLINT_PATH, null));
         confTextField.setText(prefs.get(Constants.ESLINT_CONF, Paths.get(System.getProperty("user.home"), ".eslintrc").toString()));
         txtPathValue.setText(prefs.get(Constants.PATH_ENV_VAR, null));
+        lintJavascript.setSelected(prefs.getBoolean(Constants.LINT_JAVASCRIPT, true));
+        lintTypeScript.setSelected(prefs.getBoolean(Constants.LINT_TYPESCRIPT, true));
+        lintRegExp.setText(prefs.get(Constants.LINT_REGEXP, null));
     }
 
     void store() {
         NbPreferences.forModule(ESLint.class).put(Constants.ESLINT_PATH, eslintPathTextField.getText());
         NbPreferences.forModule(ESLint.class).put(Constants.ESLINT_CONF, confTextField.getText());
         NbPreferences.forModule(ESLint.class).put(Constants.PATH_ENV_VAR, txtPathValue.getText());
+        NbPreferences.forModule(ESLint.class).put(Constants.LINT_JAVASCRIPT, Boolean.toString(this.lintJavascript.isSelected()));
+        NbPreferences.forModule(ESLint.class).put(Constants.LINT_TYPESCRIPT, Boolean.toString(this.lintTypeScript.isSelected()));
+        NbPreferences.forModule(ESLint.class).put(Constants.LINT_REGEXP, lintRegExp.getText());
     }
 
     boolean valid() {
@@ -195,7 +231,11 @@ final class ESLintPanel extends javax.swing.JPanel {
     private javax.swing.JFileChooser fileChooser;
     private javax.swing.JLabel jLabel1;
     private javax.swing.JLabel jLabel2;
+    private javax.swing.JLabel jLabel3;
     private javax.swing.JLabel jLabel4;
+    private javax.swing.JCheckBox lintJavascript;
+    private javax.swing.JTextField lintRegExp;
+    private javax.swing.JCheckBox lintTypeScript;
     private javax.swing.JButton searchButton;
     private javax.swing.JTextField txtPathValue;
     // End of variables declaration//GEN-END:variables

--- a/src/se/jocke/nb/eslint/options/OptionsUtil.java
+++ b/src/se/jocke/nb/eslint/options/OptionsUtil.java
@@ -1,0 +1,40 @@
+package se.jocke.nb.eslint.options;
+
+import java.util.logging.Logger;
+import java.util.prefs.Preferences;
+import java.util.regex.PatternSyntaxException;
+import org.openide.filesystems.FileObject;
+import org.openide.util.NbPreferences;
+import se.jocke.nb.eslint.Constants;
+import se.jocke.nb.eslint.ESLint;
+
+/**
+ *
+ * @author Stan Silvert
+ */
+public class OptionsUtil {
+    private static final Logger LOG = Logger.getLogger(OptionsUtil.class.getName());
+    private static final Preferences PREFS = NbPreferences.forModule(ESLint.class);
+    
+    // static utility class.  No instance allowed.
+    private OptionsUtil() {}
+    
+    public static boolean isLintedFile(FileObject file) {
+        if (file == null) return false;
+        
+        boolean lintJavascript = PREFS.getBoolean(Constants.LINT_JAVASCRIPT, true);
+        boolean lintTypeScript = PREFS.getBoolean(Constants.LINT_TYPESCRIPT, false);
+        String lintRegExp = PREFS.get(Constants.LINT_REGEXP, null);
+        
+        if (lintJavascript && file.getMIMEType().toLowerCase().contains("javascript")) return true;
+        if (lintTypeScript && file.getMIMEType().toLowerCase().contains("typescript")) return true;
+        
+        try {
+            if (lintRegExp != null && file.getNameExt().matches(lintRegExp)) return true;
+        } catch (PatternSyntaxException e) {
+            LOG.warning("Bad regular expression: " + e.getMessage());
+        }
+        
+        return false;
+    }
+}

--- a/src/se/jocke/nb/eslint/task/ESLintTaskScanner.java
+++ b/src/se/jocke/nb/eslint/task/ESLintTaskScanner.java
@@ -27,6 +27,7 @@ import org.openide.util.Exceptions;
 import se.jocke.nb.eslint.ESLint;
 import se.jocke.nb.eslint.error.ErrorReporter;
 import se.jocke.nb.eslint.error.LintError;
+import static se.jocke.nb.eslint.options.OptionsUtil.isLintedFile;
 
 public class ESLintTaskScanner extends PushTaskScanner {
 
@@ -92,7 +93,7 @@ public class ESLintTaskScanner extends PushTaskScanner {
                 listener.start();
             }
 
-        } else if (isJavascriptFile(file)) {
+        } else if (isLintedFile(file)) {
             Project project = FileOwnerQuery.getOwner(file);
             if (project != null) {
                 ESLintIgnore ignore = ESLintIgnore.get(project.getProjectDirectory());
@@ -117,10 +118,6 @@ public class ESLintTaskScanner extends PushTaskScanner {
 
         callback.finished();
 
-    }
-
-    public boolean isJavascriptFile(FileObject file) {
-        return file != null && !file.isFolder() && file.getExt().equalsIgnoreCase("js");
     }
 
     private class SimpleErrorReporter implements ErrorReporter {
@@ -167,14 +164,14 @@ public class ESLintTaskScanner extends PushTaskScanner {
 
         @Override
         public void fileDeleted(FileEvent fe) {
-            if (isJavascriptFile(fe.getFile()) && !ignore.isIgnored(fe.getFile())) {
+            if (isLintedFile(fe.getFile()) && !ignore.isIgnored(fe.getFile())) {
                 callback.setTasks(fe.getFile(), Collections.EMPTY_LIST);
             }
         }
 
         @Override
         public void fileChanged(FileEvent fe) {
-            if (isJavascriptFile(fe.getFile()) && !ignore.isIgnored(fe.getFile())) {
+            if (isLintedFile(fe.getFile()) && !ignore.isIgnored(fe.getFile())) {
                 callback.setTasks(fe.getFile(), Collections.EMPTY_LIST);
                 ESLint.getDefault().verify(fe.getFile(), new SimpleErrorReporter());
             }


### PR DESCRIPTION
This adds checkboxes to turn on/off linting for files with mime types containing "javascript" and/or "typescript".  Also adds a text field for a regular expression that can match file name and extension.